### PR TITLE
Correção jacobi.m

### DIFF
--- a/cap_linsis/codes/octave/metodo_de_jacobi/jacobi.m
+++ b/cap_linsis/codes/octave/metodo_de_jacobi/jacobi.m
@@ -8,7 +8,7 @@ function [x]=jacobi(A,b,x,tol,N)
       x(i) = (b(i) - A(i,[1:i-1,i+1:n])*x0([1:i-1,i+1:n]))/A(i,i);
     endfor
     #condicao de parada
-    if (norm(x-x0,'inf')<tol)
+    if ((x-x0)<tol)
       return
     endif
     #prepara nova iteracao


### PR DESCRIPTION
`if (norm(x-x0,'inf')<tol)`
A linha a cima aumentou o número de iteração necessárias para resolver um problema. Por isso proponho a atualização abaixo
`if ((x-x0)<tol)`